### PR TITLE
Issues #103 et #104

### DIFF
--- a/src/mrs/static/js/landing.js
+++ b/src/mrs/static/js/landing.js
@@ -1,6 +1,7 @@
 import ScrollReveal from 'scrollreveal'
 import '../sass/landing.sass'
 import '../sass/form.sass'
+import '../sass/animations.sass'
 import mrsrequest from './mrsrequest'
 import './contact'
 

--- a/src/mrs/static/js/mrsrequest.js
+++ b/src/mrs/static/js/mrsrequest.js
@@ -1,8 +1,11 @@
 /*global $ */
 import Cookie from 'js-cookie'
 import mrsattachment from './mrsattachment'
+import SubmitUi from './submit-ui'
 
 var listen = false
+
+var submitUi = new SubmitUi(document.querySelector('body'))
 
 var formInit = function (form) {
   // Make form ajax
@@ -98,10 +101,15 @@ var formInit = function (form) {
 }
 
 var formSubmit = function(form) {
+  // show loading overlay
+  submitUi.showSubmitLoading()
+
   var $form = $(form)
 
   if ($.active) {
     if ($(form).find('.wait').length < 1) {
+      submitUi.hideOverlay() // hide overlay and show message
+
       $(`<div class="wait card-panel orange lighten-4">
             Merci de laisser le site ouvert pendant téléchargement complêt de vos documents
         </div>`).appendTo($(form))
@@ -116,9 +124,15 @@ var formSubmit = function(form) {
       type: 'POST',
       data: $(form).serialize(),
       error: function() {
-        $(form).find(':input').each(function() {
-          $(this).removeAttr('disabled')
-        })
+        submitUi.showSubmitError('error') // Show overlay with error state
+
+        // artificially show error overlay for 0.5s so user has feedback
+        window.setTimeout(() => {
+          submitUi.hideOverlay() // hide overlay
+          $(form).find(':input').each(function() {
+            $(this).removeAttr('disabled')
+          })
+        }, 500)
       },
       success: function(data) {
         var dom = $(data)
@@ -129,13 +143,27 @@ var formSubmit = function(form) {
 
         var $error = $('.has-error')
         if ($error.length) {
-          $('html, body').animate({
-            scrollTop: $error.offset().top + 'px'
-          }, 'fast')
+          submitUi.showSubmitError('error') // show error overlay
+
+          // artificially show error overlay for 0.5s so user has feedback
+          window.setTimeout(() => {
+            submitUi.hideOverlay() // hide overlay
+
+            $('html, body').animate({
+              scrollTop: $error.offset().top + 'px'
+            }, 'fast')
+          }, 1000)
         } else {
-          $('html, body').animate({
-            scrollTop: $(form).offset().top + 'px'
-          }, 'fast')
+          submitUi.showSubmitSuccess('success') // show success overlay
+
+          // artificially show success overlay for 0.5s so user has feedback
+          window.setTimeout(() => {
+            submitUi.hideOverlay() // hide overlay
+
+            $('html, body').animate({
+              scrollTop: $(form).offset().top + 'px'
+            }, 'fast')
+          }, 1000)
         }
       },
       beforeSend: function(xhr) {

--- a/src/mrs/static/js/mrsrequest.js
+++ b/src/mrs/static/js/mrsrequest.js
@@ -125,7 +125,7 @@ var formSubmit = function(form) {
       data: $(form).serialize(),
       error: function() {
         // Show overlay with error state
-        var errorMsg = 'Une erreur est survenue'
+        var errorMsg = 'Une erreur inconnue est survenue. Veuillez reessayer dans quelques minutes, merci.'
         submitUi.showSubmitError(errorMsg, () => {
           submitUi.hideOverlay() // hide overlay
           $(form).find(':input').each(function() {
@@ -143,7 +143,7 @@ var formSubmit = function(form) {
         var $error = $('.has-error')
         if ($error.length) {
           // show error overlay
-          var errorMsg = 'Une erreur est survenue'
+          var errorMsg = 'Le formulaire contient une ou plusieurs erreurs'
           submitUi.showSubmitError(errorMsg, () => {
             submitUi.hideOverlay() // hide overlay
 
@@ -152,16 +152,17 @@ var formSubmit = function(form) {
             }, 'fast')
           })
         } else {
-          submitUi.showSubmitSuccess('success') // show success overlay
+          var successMsg = 'Soumission du formulaire reussie'
+          submitUi.showSubmitSuccess(successMsg) // show success overlay
 
-          // artificially show success overlay for 0.5s so user has feedback
+          // artificially show success overlay for 3s so user has feedback
           window.setTimeout(() => {
             submitUi.hideOverlay() // hide overlay
 
             $('html, body').animate({
               scrollTop: $(form).offset().top + 'px'
             }, 'fast')
-          }, 1000)
+          }, 3000)
         }
       },
       beforeSend: function(xhr) {

--- a/src/mrs/static/js/mrsrequest.js
+++ b/src/mrs/static/js/mrsrequest.js
@@ -124,15 +124,14 @@ var formSubmit = function(form) {
       type: 'POST',
       data: $(form).serialize(),
       error: function() {
-        submitUi.showSubmitError('error') // Show overlay with error state
-
-        // artificially show error overlay for 0.5s so user has feedback
-        window.setTimeout(() => {
+        // Show overlay with error state
+        var errorMsg = 'Une erreur est survenue'
+        submitUi.showSubmitError(errorMsg, () => {
           submitUi.hideOverlay() // hide overlay
           $(form).find(':input').each(function() {
             $(this).removeAttr('disabled')
           })
-        }, 500)
+        })
       },
       success: function(data) {
         var dom = $(data)
@@ -143,16 +142,15 @@ var formSubmit = function(form) {
 
         var $error = $('.has-error')
         if ($error.length) {
-          submitUi.showSubmitError('error') // show error overlay
-
-          // artificially show error overlay for 0.5s so user has feedback
-          window.setTimeout(() => {
+          // show error overlay
+          var errorMsg = 'Une erreur est survenue'
+          submitUi.showSubmitError(errorMsg, () => {
             submitUi.hideOverlay() // hide overlay
 
             $('html, body').animate({
               scrollTop: $error.offset().top + 'px'
             }, 'fast')
-          }, 1000)
+          })
         } else {
           submitUi.showSubmitSuccess('success') // show success overlay
 

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -112,7 +112,9 @@ export default class {
     okButton.appendChild(okButtonText)
 
     errorWrapper.style.cssText = `
+            text-align: center;
         `
+
     okButton.id = 'submit-ui-error-button'
     okButton.style.cssText = `
             height: 2rem;

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -1,0 +1,123 @@
+/**
+ * Ajax loading UI component. Updates the DOM to show loader
+ * while request is processing. Shows error or success after
+ * request is finished
+ * @param {dom el} mountPoint where to insert form submission state UI
+ */
+export default class {
+    constructor(mountPoint) {
+        this.mountPoint = mountPoint
+        this.document = this.mountPoint.ownerDocument
+
+        this.overlay = this.createOverlay()
+    }
+
+    /**
+     * Creates overlay for form submission info
+     */
+    createOverlay(){
+        // insert child node of overlay
+        const loadingOverlay = this.document.createElement('DIV')
+        loadingOverlay.style.cssText = `
+            position: fixed;
+            top: 0;
+            bottom: 0;
+            left: 0;
+            right: 0;
+
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            opacity: 0;
+            background-color: rgba(0, 0, 0, 0.2);
+            zIndex: 2;
+            transition: opacity 0.2s linear;
+        `
+        this.mountPoint.appendChild(loadingOverlay)
+
+        return loadingOverlay
+    }
+
+    /**
+     * Shows form processing overlay
+     */
+    showOverlay() {
+        this.overlay.style.opacity = 1
+    }
+
+    /**
+     * Hides form processing overlay
+     */
+    hideOverlay() {
+        this.overlay.style.opacity = 0
+    }
+
+    /**
+     * Removes overlay content
+     */
+    removeOverlayContent() {
+        if(this.overlay.childNodes.length) {
+            this.overlay.removeChild(this.overlay.firstChild)
+        }
+    }
+
+    /**
+     * Shows UI submission loader overlay
+     */
+    showSubmitLoading() {
+        this.removeOverlayContent()
+
+        const loader = this.document.createElement('DIV')
+        const text = this.document.createTextNode('Loading...')
+        loader.appendChild(text)
+
+        loader.style.cssText = `
+            height: 2rem;
+            width: 2rem;
+            background-color: red;
+        `
+
+        this.overlay.appendChild(loader)
+    }
+
+    /**
+     * Shows UI form submission error message
+     * @param {text} errorMsg error message to show
+     */
+    showSubmitError(errorMsg) {
+        this.removeOverlayContent()
+
+        const errorWrapper = this.document.createElement('DIV')
+        const errorText = this.document.createTextNode(errorMsg)
+        errorWrapper.appendChild(errorText)
+
+        errorWrapper.style.cssText = `
+            height: 2rem;
+            width: 2rem;
+            background-color: red;
+        `
+
+        this.overlay.appendChild(errorWrapper)
+    }
+
+    /**
+     * Shows UI form submission success message
+     * @param {text} successMsg success message to show
+     */
+    showSubmitSuccess(successMsg) {
+        this.removeOverlayContent()
+
+        const successWrapper = this.document.createElement('DIV')
+        const successText = this.document.createTextNode(successMsg)
+        successWrapper.appendChild(successText)
+
+        successWrapper.style.cssText = `
+            height: 2rem;
+            width: 2rem;
+            background-color: red;
+        `
+
+        this.overlay.appendChild(successWrapper)
+    }
+}

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -5,20 +5,21 @@
  * @param {dom el} mountPoint where to insert form submission state UI
  */
 export default class {
-    constructor(mountPoint) {
-        this.mountPoint = mountPoint
-        this.document = this.mountPoint.ownerDocument
+  constructor(mountPoint) {
+    this.mountPoint = mountPoint
+    this.document = this.mountPoint.ownerDocument
 
-        this.overlay = this.createOverlay()
-    }
+    this.overlay = this.createOverlay()
+    this.hideOverlay()
+  }
 
-    /**
+  /**
      * Creates overlay for form submission info
      */
-    createOverlay(){
-        // insert child node of overlay
-        const loadingOverlay = this.document.createElement('DIV')
-        loadingOverlay.style.cssText = `
+  createOverlay(){
+    // insert child node of overlay
+    const loadingOverlay = this.document.createElement('DIV')
+    loadingOverlay.style.cssText = `
             position: fixed;
             top: 0;
             bottom: 0;
@@ -29,95 +30,99 @@ export default class {
             align-items: center;
             justify-content: center;
 
-            opacity: 0;
             background-color: rgba(0, 0, 0, 0.2);
             zIndex: 2;
             transition: opacity 0.2s linear;
+            pointer-events: none;
         `
-        this.mountPoint.appendChild(loadingOverlay)
+    this.mountPoint.appendChild(loadingOverlay)
 
-        return loadingOverlay
-    }
+    return loadingOverlay
+  }
 
-    /**
+  /**
      * Shows form processing overlay
      */
-    showOverlay() {
-        this.overlay.style.opacity = 1
-    }
+  showOverlay() {
+    this.overlay.style.opacity = 1
+    this.overlay.style.pointerEvents = 'inherit'
+  }
 
-    /**
+  /**
      * Hides form processing overlay
      */
-    hideOverlay() {
-        this.overlay.style.opacity = 0
-    }
+  hideOverlay() {
+    this.overlay.style.opacity = 0
+    this.overlay.style.pointerEvents = 'none'
+  }
 
-    /**
+  /**
      * Removes overlay content
      */
-    removeOverlayContent() {
-        if(this.overlay.childNodes.length) {
-            this.overlay.removeChild(this.overlay.firstChild)
-        }
+  removeOverlayContent() {
+    if(this.overlay.childNodes.length) {
+      this.overlay.removeChild(this.overlay.firstChild)
     }
+  }
 
-    /**
+  /**
      * Shows UI submission loader overlay
      */
-    showSubmitLoading() {
-        this.removeOverlayContent()
+  showSubmitLoading() {
+    this.removeOverlayContent()
+    this.showOverlay()
 
-        const loader = this.document.createElement('DIV')
-        const text = this.document.createTextNode('Loading...')
-        loader.appendChild(text)
+    const loader = this.document.createElement('DIV')
+    const text = this.document.createTextNode('Loading...')
+    loader.appendChild(text)
 
-        loader.style.cssText = `
+    loader.style.cssText = `
             height: 2rem;
             width: 2rem;
             background-color: red;
         `
 
-        this.overlay.appendChild(loader)
-    }
+    this.overlay.appendChild(loader)
+  }
 
-    /**
+  /**
      * Shows UI form submission error message
      * @param {text} errorMsg error message to show
      */
-    showSubmitError(errorMsg) {
-        this.removeOverlayContent()
+  showSubmitError(errorMsg) {
+    this.removeOverlayContent()
+    this.showOverlay()
 
-        const errorWrapper = this.document.createElement('DIV')
-        const errorText = this.document.createTextNode(errorMsg)
-        errorWrapper.appendChild(errorText)
+    const errorWrapper = this.document.createElement('DIV')
+    const errorText = this.document.createTextNode(errorMsg)
+    errorWrapper.appendChild(errorText)
 
-        errorWrapper.style.cssText = `
+    errorWrapper.style.cssText = `
             height: 2rem;
             width: 2rem;
             background-color: red;
         `
 
-        this.overlay.appendChild(errorWrapper)
-    }
+    this.overlay.appendChild(errorWrapper)
+  }
 
-    /**
+  /**
      * Shows UI form submission success message
      * @param {text} successMsg success message to show
      */
-    showSubmitSuccess(successMsg) {
-        this.removeOverlayContent()
+  showSubmitSuccess(successMsg) {
+    this.removeOverlayContent()
 
-        const successWrapper = this.document.createElement('DIV')
-        const successText = this.document.createTextNode(successMsg)
-        successWrapper.appendChild(successText)
+    const successWrapper = this.document.createElement('DIV')
+    const successText = this.document.createTextNode(successMsg)
+    successWrapper.appendChild(successText)
 
-        successWrapper.style.cssText = `
+    successWrapper.style.cssText = `
             height: 2rem;
             width: 2rem;
             background-color: red;
         `
 
-        this.overlay.appendChild(successWrapper)
-    }
+    this.overlay.appendChild(successWrapper)
+  }
 }

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -42,8 +42,8 @@ export default class {
   }
 
   /**
-     * Shows form processing overlay
-     */
+  * Shows form processing overlay
+  */
   showOverlay() {
     this.overlay.style.opacity = 1
     this.overlay.style.pointerEvents = 'inherit'
@@ -89,7 +89,7 @@ export default class {
             border-left-color: rgba(0, 0, 0, 0);
         `
 
-      loadingTextWrapper.style.marginTop = '1rem'
+    loadingTextWrapper.style.marginTop = '1rem'
 
     this.overlay.appendChild(loader)
     this.overlay.appendChild(loadingTextWrapper)

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -148,17 +148,23 @@ export default class {
      */
   showSubmitSuccess(successMsg) {
     this.removeOverlayContent()
+    this.showOverlay()
 
     const successWrapper = this.document.createElement('DIV')
+    const successIconWrapper = this.document.createElement('DIV')
     const successText = this.document.createTextNode(successMsg)
+    successIconWrapper.innerHTML = '&#10003;'
     successWrapper.appendChild(successText)
 
     successWrapper.style.cssText = `
-            height: 2rem;
-            width: 2rem;
-            background-color: red;
+            text-align: center;
         `
 
+    successIconWrapper.style.cssText = `
+            font-size: 14vh;
+        `
+
+    this.overlay.appendChild(successIconWrapper)
     this.overlay.appendChild(successWrapper)
   }
 }

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -29,8 +29,9 @@ export default class {
             display: flex;
             align-items: center;
             justify-content: center;
+            flex-direction: column;
 
-            background-color: rgba(0, 0, 0, 0.2);
+            background-color: rgba(0, 0, 0, 0.6);
             zIndex: 2;
             transition: opacity 0.2s linear;
             pointer-events: none;
@@ -62,6 +63,7 @@ export default class {
   removeOverlayContent() {
     if(this.overlay.childNodes.length) {
       this.overlay.removeChild(this.overlay.firstChild)
+      this.removeOverlayContent() // remove other child node if need be
     }
   }
 
@@ -73,16 +75,24 @@ export default class {
     this.showOverlay()
 
     const loader = this.document.createElement('DIV')
-    const text = this.document.createTextNode('Loading...')
-    loader.appendChild(text)
+    const loadingTextWrapper = this.document.createElement('DIV')
+    const text = this.document.createTextNode('Chargement...')
+    loadingTextWrapper.appendChild(text)
 
     loader.style.cssText = `
-            height: 2rem;
-            width: 2rem;
-            background-color: red;
+            height: 10vh;
+            width: 10vh;
+            border-radius: 50%;
+            animation: rotate 1s linear;
+            animation-iteration-count: infinite;
+            border: 5px solid rgba(255, 255, 255, 1);
+            border-left-color: rgba(0, 0, 0, 0);
         `
 
+      loadingTextWrapper.style.marginTop = '1rem'
+
     this.overlay.appendChild(loader)
+    this.overlay.appendChild(loadingTextWrapper)
   }
 
   /**

--- a/src/mrs/static/js/submit-ui.js
+++ b/src/mrs/static/js/submit-ui.js
@@ -98,22 +98,48 @@ export default class {
   /**
      * Shows UI form submission error message
      * @param {text} errorMsg error message to show
+     * @param {function} callback callback to be called on error button click
      */
-  showSubmitError(errorMsg) {
+  showSubmitError(errorMsg, callback) {
     this.removeOverlayContent()
     this.showOverlay()
 
     const errorWrapper = this.document.createElement('DIV')
+    const okButton = this.document.createElement('DIV')
+    const okButtonText = this.document.createTextNode('OK')
     const errorText = this.document.createTextNode(errorMsg)
     errorWrapper.appendChild(errorText)
+    okButton.appendChild(okButtonText)
 
     errorWrapper.style.cssText = `
-            height: 2rem;
-            width: 2rem;
-            background-color: red;
         `
+    okButton.id = 'submit-ui-error-button'
+    okButton.style.cssText = `
+            height: 2rem;
+            padding: 0rem 2rem;
+            border: 1px solid white;
+            border-radius: 5%;
+            display: flex;
+            align-items: center;
+            cursor: pointer;
+            margin-top: 1rem;
+            transition: color 0.1s linear, background-color 0.1s linear;
+        `
+    okButton.onmouseenter = () => {
+      okButton.style.backgroundColor = 'rgba(0, 0, 0, 0.7)'
+    }
+
+    okButton.onmouseleave = () => {
+      okButton.style.backgroundColor = 'rgba(0, 0, 0, 0)'
+    }
+
+    okButton.onclick = () => {
+      this.hideOverlay()
+      callback()
+    }
 
     this.overlay.appendChild(errorWrapper)
+    this.overlay.appendChild(okButton)
   }
 
   /**

--- a/src/mrs/static/js/submit-ui.test.js
+++ b/src/mrs/static/js/submit-ui.test.js
@@ -6,82 +6,88 @@ import SubmitUi from './submit-ui.js'
 
 const domFixture = () => new JSDOM()
 const submitUiFactory = () => new SubmitUi(
-    domFixture().window.document.querySelector('body'))
+  domFixture().window.document.querySelector('body'))
 
 describe('submit-ui dom tests', () => {
-    test('showSubmitLoading', () => {
-        const submitUi = submitUiFactory()
-        submitUi.createOverlay()
-        const overlay = submitUi.mountPoint.querySelectorAll('div')
+  test('showSubmitLoading', () => {
+    const submitUi = submitUiFactory()
+    submitUi.createOverlay()
+    const overlay = submitUi.mountPoint.querySelectorAll('div')
 
-        expect(overlay.length).toEqual(2)
-        expect(overlay[0].style.position).toEqual('fixed')
-    })
+    expect(overlay.length).toEqual(2)
+    expect(overlay[0].style.position).toEqual('fixed')
+  })
 
-    test('showOverlay()', () => {
-        const submitUi = submitUiFactory()
-        submitUi.showOverlay()
+  test('showOverlay()', () => {
+    const submitUi = submitUiFactory()
+    submitUi.showOverlay()
 
-        const overlay = submitUi.mountPoint.querySelectorAll('div')[0]
-        expect(overlay.style.opacity).toBe('1')
-    })
+    const overlay = submitUi.mountPoint.querySelectorAll('div')[0]
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('inherit')
+  })
 
-    test('hideOverlay()', () => {
-        const submitUi = submitUiFactory()
-        submitUi.hideOverlay()
+  test('hideOverlay()', () => {
+    const submitUi = submitUiFactory()
+    submitUi.hideOverlay()
 
-        const overlay = submitUi.mountPoint.querySelectorAll('div')[0]
-        expect(overlay.style.opacity).toBe('0')
-    })
+    const overlay = submitUi.mountPoint.querySelectorAll('div')[0]
+    expect(overlay.style.opacity).toBe('0')
+    expect(overlay.style.pointerEvents).toBe('none')
+  })
 
-    test('showSubmitLoading()', () => {
-        const submitUi = submitUiFactory()
-        submitUi.removeOverlayContent = jest.fn()
+  test('showSubmitLoading()', () => {
+    const submitUi = submitUiFactory()
+    submitUi.removeOverlayContent = jest.fn()
+    submitUi.showOverlay = jest.fn()
 
-        submitUi.showSubmitLoading()
+    submitUi.showSubmitLoading()
 
-        expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
-        expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
-    })
+    expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
+    expect(submitUi.showOverlay.mock.calls).toEqual([[]])
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+  })
 
-    test('showSubmitError()', () => {
-        const submitUi = submitUiFactory()
-        submitUi.removeOverlayContent = jest.fn()
+  test('showSubmitError()', () => {
+    const submitUi = submitUiFactory()
+    submitUi.removeOverlayContent = jest.fn()
+    submitUi.showOverlay = jest.fn()
 
-        const errorMsg = 'error'
-        submitUi.showSubmitError(errorMsg)
+    const errorMsg = 'error'
+    submitUi.showSubmitError(errorMsg)
 
-        expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
-        expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
-        expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
-            .toEqual(errorMsg)
-    })
+    expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
+    expect(submitUi.showOverlay.mock.calls).toEqual([[]])
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+    expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
+      .toEqual(errorMsg)
+  })
 
-    test('showSubmitSuccess()', () => {
-        const submitUi = submitUiFactory()
-        submitUi.removeOverlayContent = jest.fn()
+  test('showSubmitSuccess()', () => {
+    const submitUi = submitUiFactory()
+    submitUi.removeOverlayContent = jest.fn()
 
-        const successMsg = 'Success !'
-        submitUi.showSubmitSuccess(successMsg)
+    const successMsg = 'Success !'
+    submitUi.showSubmitSuccess(successMsg)
 
-        expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
-        expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
-        expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
-            .toEqual(successMsg)
-    })
+    expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+    expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
+      .toEqual(successMsg)
+  })
 
-    test('removeOverlayContent', () => {
-        const submitUi = submitUiFactory()
+  test('removeOverlayContent', () => {
+    const submitUi = submitUiFactory()
 
-        // test when overlay is already empty
-        submitUi.removeOverlayContent()
+    // test when overlay is already empty
+    submitUi.removeOverlayContent()
 
-        expect(submitUi.overlay.querySelectorAll('div').length).toBe(0)
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(0)
 
-        // test when overlay has content
-        submitUi.showSubmitLoading()
-        submitUi.removeOverlayContent()
+    // test when overlay has content
+    submitUi.showSubmitLoading()
+    submitUi.removeOverlayContent()
 
-        expect(submitUi.overlay.querySelectorAll('div').length).toBe(0)
-    })
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(0)
+  })
 })

--- a/src/mrs/static/js/submit-ui.test.js
+++ b/src/mrs/static/js/submit-ui.test.js
@@ -45,7 +45,7 @@ describe('submit-ui dom tests', () => {
 
     expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
     expect(submitUi.showOverlay.mock.calls).toEqual([[]])
-    expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(2)
   })
 
   test('showSubmitError()', () => {

--- a/src/mrs/static/js/submit-ui.test.js
+++ b/src/mrs/static/js/submit-ui.test.js
@@ -86,13 +86,15 @@ describe('submit-ui dom tests', () => {
   test('showSubmitSuccess()', () => {
     const submitUi = submitUiFactory()
     submitUi.removeOverlayContent = jest.fn()
+    submitUi.showOverlay = jest.fn()
 
     const successMsg = 'Success !'
     submitUi.showSubmitSuccess(successMsg)
 
     expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
-    expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
-    expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
+    expect(submitUi.showOverlay.mock.calls).toEqual([[]])
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(2)
+    expect(submitUi.overlay.querySelectorAll('div')[1].innerHTML)
       .toEqual(successMsg)
   })
 

--- a/src/mrs/static/js/submit-ui.test.js
+++ b/src/mrs/static/js/submit-ui.test.js
@@ -1,0 +1,87 @@
+/* global describe, jest, test, expect */
+
+import jsdom from 'jsdom'
+const { JSDOM } = jsdom
+import SubmitUi from './submit-ui.js'
+
+const domFixture = () => new JSDOM()
+const submitUiFactory = () => new SubmitUi(
+    domFixture().window.document.querySelector('body'))
+
+describe('submit-ui dom tests', () => {
+    test('showSubmitLoading', () => {
+        const submitUi = submitUiFactory()
+        submitUi.createOverlay()
+        const overlay = submitUi.mountPoint.querySelectorAll('div')
+
+        expect(overlay.length).toEqual(2)
+        expect(overlay[0].style.position).toEqual('fixed')
+    })
+
+    test('showOverlay()', () => {
+        const submitUi = submitUiFactory()
+        submitUi.showOverlay()
+
+        const overlay = submitUi.mountPoint.querySelectorAll('div')[0]
+        expect(overlay.style.opacity).toBe('1')
+    })
+
+    test('hideOverlay()', () => {
+        const submitUi = submitUiFactory()
+        submitUi.hideOverlay()
+
+        const overlay = submitUi.mountPoint.querySelectorAll('div')[0]
+        expect(overlay.style.opacity).toBe('0')
+    })
+
+    test('showSubmitLoading()', () => {
+        const submitUi = submitUiFactory()
+        submitUi.removeOverlayContent = jest.fn()
+
+        submitUi.showSubmitLoading()
+
+        expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
+        expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+    })
+
+    test('showSubmitError()', () => {
+        const submitUi = submitUiFactory()
+        submitUi.removeOverlayContent = jest.fn()
+
+        const errorMsg = 'error'
+        submitUi.showSubmitError(errorMsg)
+
+        expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
+        expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+        expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
+            .toEqual(errorMsg)
+    })
+
+    test('showSubmitSuccess()', () => {
+        const submitUi = submitUiFactory()
+        submitUi.removeOverlayContent = jest.fn()
+
+        const successMsg = 'Success !'
+        submitUi.showSubmitSuccess(successMsg)
+
+        expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
+        expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+        expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
+            .toEqual(successMsg)
+    })
+
+    test('removeOverlayContent', () => {
+        const submitUi = submitUiFactory()
+
+        // test when overlay is already empty
+        submitUi.removeOverlayContent()
+
+        expect(submitUi.overlay.querySelectorAll('div').length).toBe(0)
+
+        // test when overlay has content
+        submitUi.showSubmitLoading()
+        submitUi.removeOverlayContent()
+
+        expect(submitUi.overlay.querySelectorAll('div').length).toBe(0)
+    })
+})

--- a/src/mrs/static/js/submit-ui.test.js
+++ b/src/mrs/static/js/submit-ui.test.js
@@ -54,13 +54,33 @@ describe('submit-ui dom tests', () => {
     submitUi.showOverlay = jest.fn()
 
     const errorMsg = 'error'
-    submitUi.showSubmitError(errorMsg)
+    const mockCallback = jest.fn()
+    submitUi.showSubmitError(errorMsg, mockCallback)
 
     expect(submitUi.removeOverlayContent.mock.calls).toEqual([[]])
     expect(submitUi.showOverlay.mock.calls).toEqual([[]])
-    expect(submitUi.overlay.querySelectorAll('div').length).toBe(1)
+    expect(submitUi.overlay.querySelectorAll('div').length).toBe(2)
     expect(submitUi.overlay.querySelectorAll('div')[0].innerHTML)
       .toEqual(errorMsg)
+
+      // error button events
+    const errorButton = submitUi.overlay
+      .querySelector('#submit-ui-error-button')
+
+    errorButton.onmouseenter()
+    expect(errorButton.style.backgroundColor)
+      .toEqual('rgba(0, 0, 0, 0.7)')
+
+    errorButton.onmouseleave()
+    expect(errorButton.style.backgroundColor)
+      .toEqual('rgba(0, 0, 0, 0)')
+
+    submitUi.hideOverlay = jest.fn()
+    errorButton.onclick()
+    expect(submitUi.hideOverlay.mock.calls)
+      .toEqual([[]])
+    expect(mockCallback.mock.calls)
+      .toEqual([[]])
   })
 
   test('showSubmitSuccess()', () => {

--- a/src/mrs/static/sass/animations.sass
+++ b/src/mrs/static/sass/animations.sass
@@ -1,0 +1,5 @@
+@keyframes rotate
+		from
+				transform: rotate(0deg);
+		to
+				transform: rotate(359deg);


### PR DESCRIPTION
Voila les commits pour les issues #103 et #104. Cependant, le formulaire ne re-soumet pas automatiquement lors d'une erreur serveur. Seul un message informe l'utilisateur de reessayer dans quelques instants, voire la derniere capture d'ecran ci-dessous.

Quelques captures d'ecran:

|description|capture|
|-|-|
|formulaire en chargement| ![mrs-form-loading](https://user-images.githubusercontent.com/19936648/35549388-48c4e868-0553-11e8-935d-ab383fd6d6c8.png)|
|message de succes (3s puis disparait)|![mrs-form-success](https://user-images.githubusercontent.com/19936648/35549429-911f97de-0553-11e8-816b-de387f068091.png)|
| succes apres overlay  |  ![mrs-form-post-success](https://user-images.githubusercontent.com/19936648/35549411-6d6778f2-0553-11e8-8d89-6ca7a76715ad.png)|
| message d'erreur de formulaire (il faut cliquer sur OK)  |  ![mrs-overlay-error](https://user-images.githubusercontent.com/19936648/35549455-aca7c986-0553-11e8-9b99-42ca293c7cf0.png)|
|formulaire en erreur apres overlay (remonte vers l'erreur apres avoir clique sur OK) | ![mrs-form-post-error](https://user-images.githubusercontent.com/19936648/35549401-5ebcfbd8-0553-11e8-9a36-15e12c1a98bd.png) |
| Form erreur mobile  | ![mrs-form-error-mobile](https://user-images.githubusercontent.com/19936648/35549487-d180bc2c-0553-11e8-9148-4f1a2551bc8b.png)|
| Erreur serveur| ![mrs-error-serveur](https://user-images.githubusercontent.com/19936648/35549683-a2f7d466-0554-11e8-961b-bc62253c677e.png)|