### PR TITLE
Attempt to fix ci error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
         key: dependency-cache-js-{{ checksum "yarn.lock" }}
     - run:
         name: RUN yarn install
-        command: sudo npm install -g yarn && yarn install
+        command: yarn install
     - save_cache:
         key: dependency-cache-js-{{ checksum "yarn.lock" }}
         paths:
@@ -149,7 +149,7 @@ jobs:
         key: dependency-cache-js-{{ checksum "yarn.lock" }}
     - run:
         name: RUN yarn install
-        command: sudo npm install -g yarn && yarn install
+        command: yarn install
     - save_cache:
         key: dependency-cache-js-{{ checksum "yarn.lock" }}
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
 
   js-qa:
     docker:
-    - image: circleci/node:8
+    - image: circleci/node:9
     steps:
     - checkout
     - restore_cache:
@@ -142,7 +142,7 @@ jobs:
 
   js-test:
     docker:
-    - image: circleci/node:8
+    - image: circleci/node:9
     steps:
     - checkout
     - restore_cache:


### PR DESCRIPTION
Master built fine yesterday. Re-running yesterday's pipeline fails js
jobs on::

    #!/bin/bash -eo pipefail
    sudo npm install -g yarn && yarn install

    npm ERR! path /usr/local/bin/yarn
    npm ERR! code EEXIST
    npm ERR! Refusing to delete /usr/local/bin/yarn: /opt/yarn/bin/yarn symlink target is not controlled by npm /usr/local/bin
    npm ERR! File exists: /usr/local/bin/yarn
    npm ERR! Move it away, and try again.

    npm ERR! A complete log of this run can be found in:
    npm ERR!     /roo/.npm/_logs/2018-03-16T19_11_02_366Z-debug.log
    Exited with code 1