### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ jobs:
 
   js-qa:
     docker:
-    - image: circleci/node:9
+    - image: circleci/node@sha256:0a639cc671d763fc330faf68d06884b2c4085aa7b6f129930176b09d4fb68a03
     steps:
     - checkout
     - restore_cache:
@@ -142,7 +142,7 @@ jobs:
 
   js-test:
     docker:
-    - image: circleci/node:9
+    - image: circleci/node@sha256:0a639cc671d763fc330faf68d06884b2c4085aa7b6f129930176b09d4fb68a03
     steps:
     - checkout
     - restore_cache:


### PR DESCRIPTION
Broke with new error::

    sudo npm install -g yarn && yarn install

    npm ERR! path /usr/local/bin/yarn
    npm ERR! code EEXIST
    npm ERR! Refusing to delete /usr/local/bin/yarn: /opt/yarn/bin/yarn symlink target is not controlled by npm /usr/local/bin
    npm ERR! File exists: /usr/local/bin/yarn
    npm ERR! Move it away, and try again.

    npm ERR! A complete log of this run can be found in:
    npm ERR!     /root/.npm/_logs/2018-03-16T19_24_14_070Z-debug.log
    Exited with code 1