### PR TITLE
Fugbix: date() casted into naive datetime

### DIFF
--- a/src/mrsrequest/models.py
+++ b/src/mrsrequest/models.py
@@ -186,15 +186,15 @@ def creation_datetime_and_display_id(sender, instance, **kwargs):
     if not instance.creation_datetime:
         instance.creation_datetime = timezone.now()
 
+    prefix = instance.creation_datetime.strftime('%Y%m%d')
     last = MRSRequest.objects.filter(
-        creation_datetime__date=instance.creation_datetime.date()
-    ).order_by('-display_id').first()
+        display_id__startswith=prefix,
+    ).order_by('display_id').last()
 
     number = 0
     if getattr(last, 'display_id', None) and len(str(last.display_id)) == 12:
         number = int(str(last.display_id)[-4:]) + 1
 
-    prefix = instance.creation_datetime.strftime('%Y%m%d')
     instance.display_id = '{}{:04d}'.format(prefix, number)
 signals.pre_save.connect(creation_datetime_and_display_id, sender=MRSRequest)
 

--- a/src/mrsrequest/tests/test_mrsrequest_models.py
+++ b/src/mrsrequest/tests/test_mrsrequest_models.py
@@ -1,5 +1,6 @@
 import datetime
 import pytest
+import pytz
 import uuid
 
 from django.utils import timezone
@@ -58,3 +59,18 @@ def test_display_id():
 @freeze_time('3000-12-31 13:37:42')  # forward compat and bichon <3
 def test_mrsrequest_str():
     assert str(MRSRequest(display_id=300012301111)) == '300012301111'
+
+
+@pytest.mark.django_db
+def test_mrsrequest_increments_at_minute_zero():
+    cet = pytz.timezone('Europe/Paris')
+    cet_yesterday = datetime.datetime(1999, 12, 31, 23, 55, tzinfo=cet)
+
+    assert MRSRequest.objects.create(
+        creation_datetime=cet_yesterday).display_id == '199912310000'
+
+    cet_today = datetime.datetime(2000, 1, 1, 0, 5, tzinfo=cet)
+
+    # do not count the abouve as first
+    assert MRSRequest.objects.create(
+        creation_datetime=cet_today).display_id == '200001010000'


### PR DESCRIPTION
Ca corrige le bug de display_id qui ne repart pas a 0 car le code convertissait la datetime timezone aware on date naive. Ce fix inclut un test de regression et invoke d'abord le prefixe Ymd directement a partir de la datetime timezone aware avant de chercher les potentiels predecesseurs avec le meme prefixe.


With only the test in this commit, and not the patch in models.py, the
test fails with::

    ___________________ test_mrsrequest_increments_at_minute_zero ____________________

        @pytest.mark.django_db
        def test_mrsrequest_increments_at_minute_zero():
            cet = pytz.timezone('Europe/Paris')
            cet_yesterday = datetime.datetime(1999, 12, 31, 23, 55, tzinfo=cet)

            assert MRSRequest.objects.create(
                creation_datetime=cet_yesterday).display_id == '199912310000'

            cet_today = datetime.datetime(2000, 1, 1, 0, 5, tzinfo=cet)

            # do not count the abouve as first
    >       assert MRSRequest.objects.create(
                creation_datetime=cet_today).display_id == '200001010000'
    E       AssertionError: assert '200001010001' == '200001010000'
    E         - 200001010001
    E         ?            ^
    E         + 200001010000
    E         ?            ^

Reported by @fb86