### PR TITLE
Djcall Bugfix update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ sqlparse
 holidays
 chardet
 django-denorm
-django-call>=0.0.7,<0.2
+django-call>=0.0.8,<0.2


### PR DESCRIPTION
File "/usr/local/lib/python3.6/dist-packages/djcall/models.py", line 268, in call
    logger.error(f'[djcall] {self.caller} -> Call(id={self.pk}).call(): {self.result}')
Unable to print the message and arguments - possible formatting error.