### PR TITLE
Revert "Fix #662: Use cached db session engine"

### DIFF
--- a/src/mrs/settings.py
+++ b/src/mrs/settings.py
@@ -71,9 +71,6 @@ INSTALLED_APPS = [
 
 AUTH_USER_MODEL = 'mrsuser.User'
 
-if not os.getenv('CI'):
-    SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
-
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
This reverts commit bfd35cbd7faabd0450034337552e19c6ea7dd0c6.