### PR TITLE
Fix #815: AttributeError

### DIFF
--- a/src/mrs/settings.py
+++ b/src/mrs/settings.py
@@ -260,12 +260,17 @@ if 'LETSENCRYPT_HOST' in os.environ:
     SITE_DOMAIN = os.environ.get('LETSENCRYPT_HOST').split(',')[0]
     BASE_URL = 'https://{}'.format(SITE_DOMAIN)
 
+
+def is_admin(user):
+    return user.is_authenticated and user.profile == 'admin'
+
+
 EXPLORER_CONNECTIONS = {
     'Default': 'default'
 }
 EXPLORER_DEFAULT_CONNECTION = 'default'
-EXPLORER_PERMISSION_VIEW = lambda u: u.profile == 'admin'  # noqa
-EXPLORER_PERMISSION_CHANGE = lambda u: u.profile == 'admin'  # noqa
+EXPLORER_PERMISSION_VIEW = EXPLORER_PERMISSION_CHANGE = is_admin
+
 
 LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO')
 if os.getenv('LOG'):


### PR DESCRIPTION
::

    AttributeError: 'AnonymousUser' object has no attribute 'profile'
    (4 additional frame(s) were not displayed)
    ...
      File "explorer/views.py", line 91, in dispatch
        if not self.has_permission(request, *args, **kwargs):
      File "explorer/views.py", line 82, in has_permission
        return handler(request, *args, **kwargs)
      File "explorer/permissions.py", line 18, in view_permission_list
        return app_settings.EXPLORER_PERMISSION_VIEW(request.user)\
      File "mrs/settings.py", line 267, in <lambda>
        EXPLORER_PERMISSION_VIEW = lambda u: u.profile == 'admin'  # noqa

    AttributeError: 'AnonymousUser' object has no attribute 'profile'