### PR TITLE
Fix #916: remove spooled job concurrency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,6 @@ EXPOSE 6789
 CMD /usr/bin/dumb-init bash -euxc "mrs migrate --noinput && uwsgi \
   --spooler=${UWSGI_SPOOLER_MOUNT}/mail \
   --spooler=${UWSGI_SPOOLER_MOUNT}/stat \
-  --spooler-processes 8 \
   --socket=0.0.0.0:6789 \
   --chdir=/app \
   --plugin=python3,http,router_static,router_cache \


### PR DESCRIPTION
This new configuration sets one spooler process for mail, and one for
stat:

> The --spooler <directory> option allows you to generate a spooler
> process, while the --spooler-processes <n> allows you to set how many
> processes to spawn for every spooler.