### PR TITLE
Mettre des champs de texte non-numeriques qui n'affectent pas le scroll

### DIFF
--- a/src/mrs/static/js/mrsrequest.js
+++ b/src/mrs/static/js/mrsrequest.js
@@ -128,6 +128,10 @@ var formInit = function (form) {
     if (isNaN(i) || i < 1) {
       return
     }
+    if (i > 150) {
+      i = 150
+      $iterativeNumber.val('150')
+    }
     i--  // compensate for first form that starts at 0
 
     // remove all transport lines that have a form number above the i var

--- a/src/mrs/static/js/mrsrequest.js
+++ b/src/mrs/static/js/mrsrequest.js
@@ -109,7 +109,7 @@ var formInit = function (form) {
     if ($iterativeShow.is(':checked')) {
       $iterativeNumberContainer.slideDown()
     } else {
-      $iterativeNumberContainer.hide()
+      $iterativeNumberContainer.slideUp()
       $iterativeNumberContainer.find(':input').val('1')
       $(form).find('[name*=-date_depart]:not(:first)').each(function() {
         $(this).parents('div.layout-row.row').remove()
@@ -179,9 +179,9 @@ var formInit = function (form) {
       return field.length && parseFloat(field.val().replace(',', '.')) > 0
     }
     if (active($expensevp) || active($parking)) {
-      $billvps.show()
+      $billvps.slideDown()
     } else {
-      $billvps.hide()
+      $billvps.slideUp()
     }
   }
   $expensevp.on('input', expensevpChange)
@@ -208,10 +208,10 @@ var formInit = function (form) {
     if ($('[name=trip_kind]:checked').val() == 'simple') {
       $('[name*=date_return]').val('')
       $('[name*=date_return]').prop('disabled', true)
-      $('[name*=date_return]').parent().parent().hide()
+      $('[name*=date_return]').parent().parent().fadeOut()
     } else {
       $('[name*=date_return]').prop('disabled', false)
-      $('[name*=date_return]').parent().parent().show()
+      $('[name*=date_return]').parent().parent().fadeIn()
     }
   })
   confirming || $('[name=trip_kind]').trigger('change')

--- a/src/mrs/tests/response_fixtures/FrontCrawlTest.test_crawl/demande.content
+++ b/src/mrs/tests/response_fixtures/FrontCrawlTest.test_crawl/demande.content
@@ -243,7 +243,7 @@
 
 <div class="row">
     <div class="input-field col s12" id="id_distancevp_container">
-        <input id="id_distancevp" min="0" name="distancevp" type="number"/>
+        <input id="id_distancevp" name="distancevp" type="text"/>
         <label for="id_distancevp">Distance (km)</label>
         <div class="help-block">Total des kilomètres parcourus: en cas de transports aller retour, ou de transports itératifs indiquer le nombre total de km parcours. (ex.pour 2 trajets de 40 km, indiquer 80 km)</div>
     </div>
@@ -256,7 +256,7 @@
 
 <div class="row">
     <div class="input-field col s12" id="id_expensevp_container">
-        <input id="id_expensevp" min="0" name="expensevp" step="0.01" type="number" value="0"/>
+        <input id="id_expensevp" name="expensevp" type="text" value="0"/>
         <label class="active" for="id_expensevp">Frais de péage</label>
         <div class="help-block">Somme totale des frais de péage (en € TTC)</div>
     </div>
@@ -265,7 +265,7 @@
 
 <div class="row">
     <div class="input-field col s12" id="id_parking_expensevp_container">
-        <input id="id_parking_expensevp" min="0" name="parking_expensevp" step="0.01" type="number" value="0"/>
+        <input id="id_parking_expensevp" name="parking_expensevp" type="text" value="0"/>
         <label class="active" for="id_parking_expensevp">Frais de parking</label>
         <div class="help-block">Somme totale des frais de parking (en € TTC)</div>
     </div>
@@ -308,7 +308,7 @@
                     <div id="atp-form" style="display: none">
                           <div class="row">
     <div class="input-field col s12" id="id_expenseatp_container">
-        <input id="id_expenseatp" min="0" name="expenseatp" step="0.01" type="number" value="0"/>
+        <input id="id_expenseatp" name="expenseatp" type="text" value="0"/>
         <label class="active" for="id_expenseatp">Frais de transports</label>
         <div class="help-block">Somme totale des frais de transport en commun (en € TTC)</div>
     </div>

--- a/src/mrsrequest/forms.py
+++ b/src/mrsrequest/forms.py
@@ -77,12 +77,7 @@ class MRSRequestCreateForm(forms.ModelForm):
             'Somme totale des frais de transport en commun (en € TTC)'
         ),
         required=False,
-        widget=forms.NumberInput(
-            attrs=dict(
-                min='0',
-                step='0.01',
-            )
-        )
+        widget=forms.TextInput,
     )
 
     expensevp = forms.DecimalField(
@@ -94,12 +89,7 @@ class MRSRequestCreateForm(forms.ModelForm):
             'Somme totale des frais de péage (en € TTC)'
         ),
         required=False,
-        widget=forms.NumberInput(
-            attrs=dict(
-                min='0',
-                step='0.01',
-            )
-        )
+        widget=forms.TextInput,
     )
 
     parking_expensevp = forms.DecimalField(
@@ -109,12 +99,7 @@ class MRSRequestCreateForm(forms.ModelForm):
         label='Frais de parking',
         help_text='Somme totale des frais de parking (en € TTC)',
         required=False,
-        widget=forms.NumberInput(
-            attrs=dict(
-                min='0',
-                step='0.01',
-            )
-        )
+        widget=forms.TextInput,
     )
 
     layouts = dict(
@@ -162,6 +147,9 @@ class MRSRequestCreateForm(forms.ModelForm):
             'modevp',
             'modeatp',
         ]
+        widgets = dict(
+            distancevp=forms.TextInput
+        )
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('initial', {})


### PR DESCRIPTION
Ceci fait suite a la demande orale de mardi de desactiver le scroll sur les champs de depenses etc.

De meme, une secu a ete mise pour ne pas permettre plus de 150 trajets, chiffre basé sur un maximum en db de prod de 133. Cela evite que l'utilisateur plante son navigateur en mettant 9999 par erreur.

Enfin, tous les effets des transitions sur le formulaire de front ont ete cajolees.