### PR TITLE
Filter out imported requests from monthly email exports

### DIFF
--- a/src/caisse/models.py
+++ b/src/caisse/models.py
@@ -122,7 +122,10 @@ def monthly_mail(force=False):
     today = today()
 
     for caisse in Caisse.objects.filter(active=True).order_by('pk'):
-        objects = caisse.mrsrequest_set.all().status(
+        objects = caisse.mrsrequest_set.filter(
+            mandate_datevp=None,
+            mandate_dateatp=None,
+        ).status(
             'validated'
         ).created(
             date__gte=date(

--- a/src/caisse/models.py
+++ b/src/caisse/models.py
@@ -91,8 +91,7 @@ def daily_mail(force=False):
         mrsrequests = caisse.mrsrequest_set.all().status('new').order_by(
             'creation_datetime')
 
-        num = len(mrsrequests)
-        if not num:
+        if not len(mrsrequests):
             continue
 
         context = dict(

--- a/src/caisse/tests/test_caisse_models.py
+++ b/src/caisse/tests/test_caisse_models.py
@@ -49,3 +49,5 @@ def test_monthly_mail(mailoutbox, django_assert_num_queries):
     assert mailoutbox[1].attachments[0][0] == '2018-6-stats.csv'
     assert mailoutbox[1].attachments[0][1] == 'caisse;id;nir;naissance;transport;mandatement;base;montant;bascule;finess;adeli\n222;201805010001;2333333333333;30/04/2000;29/04/2018;;;;;;\n222;201805030000;1223123123123;29/05/2000;01/05/2018;;;;;;\n222;201805030001;1223123123123;29/05/2000;01/04/2018;;;;;;'  # noqa
     assert mailoutbox[1].attachments[0][2] == 'text/csv'
+
+    assert len(mailoutbox) == 2

--- a/src/mrs/tests/data.json
+++ b/src/mrs/tests/data.json
@@ -423,6 +423,15 @@
     }
 },
 {
+    "model": "mrsrequest.transport",
+    "pk": 11,
+    "fields": {
+        "mrsrequest": "f5ac697c-d4cd-34d4-89bc-39d1f606dd05",
+        "date_depart": "2018-04-27",
+        "date_return": "2018-04-28"
+    }
+},
+{
     "model": "mrsuser.user",
     "pk": 1,
     "fields": {
@@ -1177,8 +1186,8 @@
         },
         "conflicts_accepted": 0,
         "conflicts_resolved": 0,
-        "taxi_cost": "7.37",
-        "saving": "5.37",
+        "taxi_cost": "10.83",
+        "saving": "8.83",
         "delay": "0.36"
     }
 }

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
@@ -167,7 +167,7 @@
                             Coût théorique du trajet en taxi
                         </td>
                         <td>
-                            7.37 €
+                            10.83 €
                         </td>
                     </tr>
                     <tr>
@@ -175,7 +175,7 @@
                             Economie calculée
                         </td>
                         <td>
-                            5.37 €
+                            8.83 €
                         </td>
                     </tr>
                     </tbody></table>
@@ -231,7 +231,7 @@
         <div class="card">
             <div class="card-content">
                 <div class="card-title">
-                    Date de Transport
+                    Dates de Transports
                 </div>
                 <table class="centered highlight">
                     <thead>
@@ -242,6 +242,15 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <tr class="odd">
+                            <td>1</td>
+                            <td>
+                                27/04/2018
+                            </td>
+                            <td>
+                                28/04/2018
+                            </td>
+                        </tr>
                         
                     </tbody>
                 </table>

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
@@ -1,4 +1,4 @@
 {
-    "query_count": 15,
+    "query_count": 16,
     "status_code": 200
 }

--- a/src/mrs/tests/response_fixtures/StatCrawlTest.test_crawl/admin/stat/totaldate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
+++ b/src/mrs/tests/response_fixtures/StatCrawlTest.test_crawl/admin/stat/totaldate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
@@ -77,7 +77,7 @@
     </div>
     <div class="col s4">
       <p>
-        Econnomies réalisées: 5.37€
+        Econnomies réalisées: 8.83€
       </p>
       <p>
         Nombre d'assurés ayant basculés pendant la période: 1

--- a/src/mrs/tests/response_fixtures/StatCrawlTest.test_crawl/admin/statdate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
+++ b/src/mrs/tests/response_fixtures/StatCrawlTest.test_crawl/admin/statdate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
@@ -77,7 +77,7 @@
     </div>
     <div class="col s4">
       <p>
-        Econnomies réalisées: 5.37€
+        Econnomies réalisées: 8.83€
       </p>
       <p>
         Nombre d'assurés ayant basculés pendant la période: 1

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest.content
@@ -397,7 +397,7 @@
             
                 <td>aaaaaaa</td>
             
-                <td>5,37</td>
+                <td>8,83</td>
             
                 <td>
                 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
@@ -167,7 +167,7 @@
                             Coût théorique du trajet en taxi
                         </td>
                         <td>
-                            7.37 €
+                            10.83 €
                         </td>
                     </tr>
                     <tr>
@@ -175,7 +175,7 @@
                             Economie calculée
                         </td>
                         <td>
-                            5.37 €
+                            8.83 €
                         </td>
                     </tr>
                     </tbody></table>
@@ -231,7 +231,7 @@
         <div class="card">
             <div class="card-content">
                 <div class="card-title">
-                    Date de Transport
+                    Dates de Transports
                 </div>
                 <table class="centered highlight">
                     <thead>
@@ -242,6 +242,15 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <tr class="odd">
+                            <td>1</td>
+                            <td>
+                                27/04/2018
+                            </td>
+                            <td>
+                                28/04/2018
+                            </td>
+                        </tr>
                         
                     </tbody>
                 </table>

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
@@ -1,4 +1,4 @@
 {
-    "query_count": 15,
+    "query_count": 16,
     "status_code": 200
 }

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequeststatus=2000.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequeststatus=2000.content
@@ -335,7 +335,7 @@
             
                 <td>aaaaaaa</td>
             
-                <td>5,37</td>
+                <td>8,83</td>
             
                 <td>
                 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/stat/totaldate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/stat/totaldate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018.content
@@ -78,7 +78,7 @@
     </div>
     <div class="col s4">
       <p>
-        Econnomies réalisées: 5.37€
+        Econnomies réalisées: 8.83€
       </p>
       <p>
         Nombre d'assurés ayant basculés pendant la période: 1

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/statdate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/statdate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018.content
@@ -78,7 +78,7 @@
     </div>
     <div class="col s4">
       <p>
-        Econnomies réalisées: 5.37€
+        Econnomies réalisées: 8.83€
       </p>
       <p>
         Nombre d'assurés ayant basculés pendant la période: 1

--- a/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
+++ b/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
@@ -167,7 +167,7 @@
                             Coût théorique du trajet en taxi
                         </td>
                         <td>
-                            7.37 €
+                            10.83 €
                         </td>
                     </tr>
                     <tr>
@@ -175,7 +175,7 @@
                             Economie calculée
                         </td>
                         <td>
-                            5.37 €
+                            8.83 €
                         </td>
                     </tr>
                     </tbody></table>
@@ -231,7 +231,7 @@
         <div class="card">
             <div class="card-content">
                 <div class="card-title">
-                    Date de Transport
+                    Dates de Transports
                 </div>
                 <table class="centered highlight">
                     <thead>
@@ -242,6 +242,15 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <tr class="odd">
+                            <td>1</td>
+                            <td>
+                                27/04/2018
+                            </td>
+                            <td>
+                                28/04/2018
+                            </td>
+                        </tr>
                         
                     </tbody>
                 </table>

--- a/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
+++ b/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
@@ -1,4 +1,4 @@
 {
-    "query_count": 15,
+    "query_count": 16,
     "status_code": 200
 }

--- a/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/stat/totaldate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
+++ b/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/stat/totaldate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
@@ -77,7 +77,7 @@
     </div>
     <div class="col s4">
       <p>
-        Econnomies réalisées: 5.37€
+        Econnomies réalisées: 8.83€
       </p>
       <p>
         Nombre d'assurés ayant basculés pendant la période: 1

--- a/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/statdate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
+++ b/src/mrs/tests/response_fixtures/SuperviseurCrawlTest.test_crawl/admin/statdate__gte=01%2F05%2F2018&ampdate__lte=31%2F05%2F2018&ampcaisse=1.content
@@ -77,7 +77,7 @@
     </div>
     <div class="col s4">
       <p>
-        Econnomies réalisées: 5.37€
+        Econnomies réalisées: 8.83€
       </p>
       <p>
         Nombre d'assurés ayant basculés pendant la période: 1

--- a/src/mrs/tests/response_fixtures/SupportCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
+++ b/src/mrs/tests/response_fixtures/SupportCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.content
@@ -167,7 +167,7 @@
                             Coût théorique du trajet en taxi
                         </td>
                         <td>
-                            7.37 €
+                            10.83 €
                         </td>
                     </tr>
                     <tr>
@@ -175,7 +175,7 @@
                             Economie calculée
                         </td>
                         <td>
-                            5.37 €
+                            8.83 €
                         </td>
                     </tr>
                     </tbody></table>
@@ -231,7 +231,7 @@
         <div class="card">
             <div class="card-content">
                 <div class="card-title">
-                    Date de Transport
+                    Dates de Transports
                 </div>
                 <table class="centered highlight">
                     <thead>
@@ -242,6 +242,15 @@
                         </tr>
                     </thead>
                     <tbody>
+                        <tr class="odd">
+                            <td>1</td>
+                            <td>
+                                27/04/2018
+                            </td>
+                            <td>
+                                28/04/2018
+                            </td>
+                        </tr>
                         
                     </tbody>
                 </table>

--- a/src/mrs/tests/response_fixtures/SupportCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
+++ b/src/mrs/tests/response_fixtures/SupportCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05.metadata
@@ -1,4 +1,4 @@
 {
-    "query_count": 15,
+    "query_count": 16,
     "status_code": 200
 }

--- a/src/mrsstat/tests/test_mrsstat.json
+++ b/src/mrsstat/tests/test_mrsstat.json
@@ -233,7 +233,7 @@
         "mrsrequest_total_new": 5,
         "mrsrequest_total_rejected": 1,
         "mrsrequest_total_validated": 2,
-        "savings": "5.37",
+        "savings": "8.83",
         "validation_average_delay": "0.36"
     },
     "model": "mrsstat.stat",
@@ -281,7 +281,7 @@
         "mrsrequest_total_new": 8,
         "mrsrequest_total_rejected": 1,
         "mrsrequest_total_validated": 4,
-        "savings": "5.37",
+        "savings": "8.83",
         "validation_average_delay": "0.36"
     },
     "model": "mrsstat.stat",

--- a/src/mrsstat/tests/test_mrsstat.py
+++ b/src/mrsstat/tests/test_mrsstat.py
@@ -43,19 +43,19 @@ def test_stat_update():
 
     stat_update_person(Person, instance=req.insured)
     req.refresh_from_db()
-    assert f'{req.saving}' == '5.37'
+    assert f'{req.saving}' == '8.83'
 
     stats = Stat.objects.filter(
         date=req.status_datetime.date(),
         caisse__in=(req.caisse, None),
     )
     for stat in stats:
-        assert str(stat.savings) == '5.37'
+        assert str(stat.savings) == '8.83'
 
     req.distancevp *= 2
     req.save()
     req.refresh_from_db()
-    assert f'{req.saving}' == '12.74'
+    assert f'{req.saving}' == '16.20'
 
     # test that it refreshed stats !
     update_stat_for_mrsrequest(pk=req.pk)
@@ -65,7 +65,7 @@ def test_stat_update():
         caisse__in=(req.caisse, None),
     )
     for stat in stats:
-        assert str(stat.savings) == '12.74'
+        assert str(stat.savings) == '16.20'
 
 
 @freeze_time('2018-05-06 13:37:42')


### PR DESCRIPTION
Ce patch corrige le probleme d'email mensuel qui ne devait pas contiennir les demandes qui ont ete importees.

    Filter out imported requests from monthly email exports

    Also add transport date to imported test MRSRequest fixture
    201805020002.

    MRSRequest 201805020002 should not appear in monthly email because it
    has a mandate date which means that it has been imported.

    As such, it was expected for the developer to see this MRSRequest *not*
    appear in the test result.

    However, it didn't appear in the test result for another reason: it had
    no transport date. As such, it received the treatment of pre-MRS legacy
    data which is to be skipped.

    201805020002 was skipped which passed test indeed, but not for the
    appropriate reason.

    As such, this patch adds transport dates to 201805020002, which of
    course updates the resulting detail page fixture, but also some other
    stat tests.