### PR TITLE
Passage à jquery 3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "fstream": "^1.0.12",
     "jest": "^23.0.1",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.1",
     "jquery-ui": "^1.12.1",
     "js-cookie": "^2.2.0",
     "jsdom": "^12",


### PR DESCRIPTION
Le passage à jquery 3.4.1 devrait permettre de lever les deux issues Sentry liées à la fonction shift. 
A voir si l'issue continue malgré tout à se produire par la suite, notamment sur IE.