### PR TITLE
Migration de raven vers sentry-sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ django-threadlocals
 django-material>=1.3,<1.4
 django-jpic-jfu
 djcli
-raven
+gitpython
+sentry-sdk
 requests
 django-humanize==0.1.2
 crudlfap==0.7.36

--- a/src/mrs/context_processors.py
+++ b/src/mrs/context_processors.py
@@ -20,8 +20,7 @@ def settings(request):
         INSTANCE=s.INSTANCE,
         PREFIX=s.PREFIX,
         RELEASE=s.RELEASE,
-        SENTRY_DSN=s.SENTRY_PUBLIC_DSN,
-        SENTRY_CONFIG=s.RAVEN_PUBLIC_CONFIG,
+        SENTRY_DSN=s.SENTRY_PUBLIC_DSN
     )
 
 

--- a/src/mrs/jinja2/base.html
+++ b/src/mrs/jinja2/base.html
@@ -2,12 +2,9 @@
 
 {% block bundles %}
 {%- if SENTRY_DSN %}
-<script src="https://cdn.ravenjs.com/3.26.4/raven.min.js" crossorigin="anonymous"></script>
+<script src="https://browser.sentry-cdn.com/5.5.0/bundle.min.js" crossorigin="anonymous"></script>
 <script type="text/javascript">
-Raven.config(
-  '{{ SENTRY_DSN }}',
-  '{{ SENTRY_CONFIG|tojson|safe }}',
-).install()
+Sentry.init({dsn: '{{ SENTRY_DSN }}', environment: '{{ INSTANCE }}', release: '{{ RELEASE }}'})
 </script>
 {%- endif %}
 {{ render_bundle('crudlfap', attrs='data-turbolinks-track="reload"') }}

--- a/src/mrs/settings.py
+++ b/src/mrs/settings.py
@@ -18,7 +18,10 @@ from crudlfap.settings import (
     DJANGO_APPS,
 )
 
-from raven.transport.requests import RequestsHTTPTransport
+import git
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.transport import HttpTransport
 
 from mrs.context_processors import strip_password
 
@@ -209,12 +212,6 @@ else:
     EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', EMAIL_BACKEND)
 
-try:
-    import raven  # noqa
-except ImportError:
-    raven = None
-else:
-    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
 
 PREFIX = os.getenv('PLAYLABS_PREFIX', 'mrs')
 INSTANCE = os.getenv('PLAYLABS_INSTANCE', 'dev')
@@ -239,26 +236,44 @@ TITLE_SUFFIX = ""
 if INSTANCE.upper() != 'PRODUCTION':
     TITLE_SUFFIX = " ({})".format(INSTANCE.upper())
 
+# Intégration de Sentry-sdk
+# https://docs.sentry.io/platforms/python/django/
+
+# Paramètres
+SENTRY_DSN = os.getenv('SENTRY_DSN', '')
+
+# Récupération du hash de la release courante
 RELEASE = os.getenv('GIT_COMMIT', '')
 if not RELEASE:
     repo = os.path.join(os.path.dirname(__file__), '..', '..')
     if os.path.exists(os.path.join(repo, '.git')):
-        RELEASE = raven.fetch_git_sha(repo)
 
-RAVEN_CONFIG = dict(
-    dsn=os.getenv('SENTRY_DSN', ''),
-    transport=RequestsHTTPTransport,
+        repo = git.Repo(search_parent_directories=False)
+        RELEASE = repo.head.object.hexsha
+
+# Initialisation de Sentry côté Django
+sentry_sdk.init(
+    dsn=SENTRY_DSN,
+    integrations=[DjangoIntegration()],
+    release=RELEASE,
+    environment=INSTANCE,
+    transport=HttpTransport
 )
-RAVEN_PUBLIC_CONFIG = dict(
+
+# Paramètres Sentry publics pour les erreurs côté Front,
+# intégrés dans le context_processor
+SENTRY_PUBLIC_CONFIG = dict(
     environment=INSTANCE,
     release=RELEASE,
 )
-RAVEN_CONFIG.update(RAVEN_PUBLIC_CONFIG)
-SENTRY_PUBLIC_DSN = strip_password(RAVEN_CONFIG['dsn'])
 
+# Retrait du secret
+SENTRY_PUBLIC_DSN = strip_password(SENTRY_DSN)
+
+# Paramètres Sentry publics pour les erreurs côté Front / Crudlfap
 CRUDLFAP_TEMPLATE_BACKEND['OPTIONS']['constants'].update(dict(
     SENTRY_DSN=SENTRY_PUBLIC_DSN,
-    SENTRY_CONFIG=RAVEN_PUBLIC_CONFIG,
+    SENTRY_CONFIG=SENTRY_PUBLIC_CONFIG,
 ))
 
 BASE_URL = 'http://localhost:8000'

--- a/src/mrs/static/js/crudlfap.js
+++ b/src/mrs/static/js/crudlfap.js
@@ -1,4 +1,3 @@
-/* global Raven */
 // Add our controllers to crudlfap's
 
 import { definitionsFromContext } from 'stimulus/webpack-helpers'
@@ -9,5 +8,5 @@ application.load(definitionsFromContext(context))
 
 application.handleError = (error, message, detail) => {
   if (console.warn !== undefined) console.warn(message, detail) // eslint-disable-line no-console
-  if (window.Raven !== undefined) Raven.captureException(error)
+  if (window.Sentry !== undefined) Sentry.captureException(error)
 }

--- a/src/mrs/templates/base.html
+++ b/src/mrs/templates/base.html
@@ -63,13 +63,9 @@
     </div>
 
     {% if SENTRY_DSN %}
-    <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js" crossorigin="anonymous"></script>
-    {{ SENTRY_CONFIG|json_script:'sentry-config' }}
+    <script src="https://browser.sentry-cdn.com/5.5.0/bundle.min.js" crossorigin="anonymous"></script>
     <script type="text/javascript">
-    Raven.config(
-      '{{ SENTRY_DSN }}',
-      JSON.parse(document.getElementById('sentry-config').textContent)
-    ).install()
+        Sentry.init({dsn: '{{ SENTRY_DSN }}', environment: '{{ INSTANCE }}', release: '{{ RELEASE }}'})
     </script>
     {% endif %}
 

--- a/src/mrs/urls.py
+++ b/src/mrs/urls.py
@@ -5,6 +5,7 @@ from django.contrib import admin
 from django.views.decorators.cache import cache_page
 from django.urls import include, path
 
+from mrs.views import NotFoundView
 from contact.views import ContactView
 from mrsrequest.views import (
     MRSRequestCancelView,
@@ -62,6 +63,8 @@ urlpatterns = [
     path('doc/', include('django.contrib.admindocs.urls')),
     path('pro/', include('pro.urls', namespace='pro')),
 ]
+
+handler404 = NotFoundView.as_view()
 
 if 'debug_toolbar' in settings.INSTALLED_APPS and settings.DEBUG:  # noqa pragma: no cover
     import debug_toolbar

--- a/src/mrs/views.py
+++ b/src/mrs/views.py
@@ -14,6 +14,8 @@ from django.views import generic
 from caisse.models import Caisse
 from mrsrequest.models import MRSRequest
 from person.models import Person
+from django.http import HttpResponseNotFound
+from sentry_sdk import capture_message
 
 
 class Dashboard(crudlfap.TemplateView):
@@ -142,3 +144,13 @@ class StaticView(generic.View):
             response['Access-Control-Allow-Origin'] = self.allow_origin
 
         return response
+
+
+class NotFoundView(generic.View):
+
+    def get(self, request, *args, **kwargs):
+        capture_message("Page not found",
+                        level="error")
+
+        # We'll soon get a cool custom 404 page to render, but meanwhile
+        return HttpResponseNotFound("Page non trouvée")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,6 @@ var cfg = {
       - FAQ (/faq)
       - legal (/legal)
       - statistics (/stats)
-
     base.html:
       - header
       - footer


### PR DESCRIPTION
Migration réalisée pour transmettre les erreurs Django / 500, les erreurs 404, et les erreurs côté Front