### PR TITLE
Save user agent number after import

### DIFF
--- a/src/mrsuser/crudlfap.py
+++ b/src/mrsuser/crudlfap.py
@@ -399,6 +399,8 @@ class ImportView(crudlfap.FormView):
         groups = row['profil'].split(',')
         user.add_groups(groups)
 
+        user.number = agent_nb
+
         caisses_ids = row['numero organisme'].split(',')
         caisses = []
         for id in caisses_ids:


### PR DESCRIPTION
Les utilisateurs importés n'avaient pas leur numéro d'agent enregistré en base après l'import, alors que ce champ est obligatoire dans les différents formulaires, ce qui pose des problèmes lorsque l'admin local souhaite affecter un utilisateur à sa caisse alors qu'il n'a pas de numéro d'agent.

Le champ number est à repeupler à partir du champ username sur staging et prod.