### PR TITLE
Fix #1178

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -169,6 +169,7 @@ steps:
   - bigsudo
     ./ansible/deploy.yml
     project=test-$DRONE_BRANCH
+    lifetime=604800
     compose_django_image=betagouv/mrs:$DRONE_COMMIT
     compose_django_build=
     compose=docker-compose.yml,docker-compose.maildev.yml,docker-compose.traefik.yml

--- a/src/institution/tests/test_mrsrequest_iframe.json
+++ b/src/institution/tests/test_mrsrequest_iframe.json
@@ -1,7 +1,7 @@
 [
 {
     "fields": {
-        "attachment_file": "e29db065-0566-48be-822d-66bd3277d823-761d1d1d-effc-4d8c-8151-7f2e82b996dc.png",
+        "attachment_file": "e29db065-0566-48be-822d-66bd3277d823-79920162-da77-4ac7-8c68-ca50d311bab0.png",
         "creation_datetime": "2017-12-19T13:33:37Z",
         "filename": "test_institutionmrsrequestcreateview_story.jpg",
         "mrsrequest_uuid": "e29db065-0566-48be-822d-66bd3277d823"

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/13751dc2-18bb-4925-a8b4-84383a042bae/update.content
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/13751dc2-18bb-4925-a8b4-84383a042bae/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/767b8123-2134-48cb-8177-0c411309a0b1/update.content
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/767b8123-2134-48cb-8177-0c411309a0b1/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/ad2ac0fd-95e6-4b3f-9a4b-ef581e9e07c2/update.content
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/ad2ac0fd-95e6-4b3f-9a4b-ef581e9e07c2/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/c697cf5a-dc4d-434d-89bc-1f606d05d39d/update.content
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/c697cf5a-dc4d-434d-89bc-1f606d05d39d/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05/update.content
+++ b/src/mrs/tests/response_fixtures/LiquidateurCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/13751dc2-18bb-4925-a8b4-84383a042bae/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/13751dc2-18bb-4925-a8b4-84383a042bae/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/35fe2514-b1e7-4f97-955a-f163788afdf3/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/35fe2514-b1e7-4f97-955a-f163788afdf3/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/767b8123-2134-48cb-8177-0c411309a0b1/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/767b8123-2134-48cb-8177-0c411309a0b1/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/770efeec-34a8-49f6-ab04-c6dde9a4a679/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/770efeec-34a8-49f6-ab04-c6dde9a4a679/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/ad2ac0fd-95e6-4b3f-9a4b-ef581e9e07c2/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/ad2ac0fd-95e6-4b3f-9a4b-ef581e9e07c2/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/b83cd5c8-ae0a-4efd-b1ba-6e35775f10bb/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/b83cd5c8-ae0a-4efd-b1ba-6e35775f10bb/update.content
@@ -47,24 +47,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/c697cf5a-dc4d-434d-89bc-1f606d05d39d/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/c697cf5a-dc4d-434d-89bc-1f606d05d39d/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05/update.content
+++ b/src/mrs/tests/response_fixtures/SuperuserCrawlTest.test_crawl/admin/mrsrequest/f5ac697c-d4cd-34d4-89bc-39d1f606dd05/update.content
@@ -53,24 +53,6 @@
         
     </div>
 </div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_last_name_container">
-        <input id="id_last_name" maxlength="70" name="last_name" placeholder="" type="text"/>
-        <label for="id_last_name">Nom de famille</label>
-        
-    </div>
-</div>
- 
-
-<div class="row">
-    <div class="input-field col s12 required" id="id_email_container">
-        <input id="id_email" maxlength="254" name="email" placeholder="" type="text"/>
-        <label for="id_email">Adresse email</label>
-        
-    </div>
-</div>
 
     
 

--- a/src/mrsrequest/crudlfap.py
+++ b/src/mrsrequest/crudlfap.py
@@ -762,14 +762,16 @@ class MRSRequestImport(crudlfap.FormMixin, crudlfap.ModelView):
 
 class MRSRequestUpdateView(crudlfap.UpdateView):
     allowed_groups = ['Admin', 'UPN']
-    extra_form_classes = dict(
-        person=forms.modelform_factory(
-            Person,
-            form=PersonForm,
-            fields=['nir', 'birth_date', 'first_name']
-        )
-    )
-    extra_form_classes['person'].layout = None  # cancel out material layout
+
+    class PersonUpdateForm(PersonForm):
+        layout = None
+        last_name = None
+        email = None
+
+        class Meta:
+            fields = ['nir', 'birth_date', 'first_name']
+            model = Person
+    extra_form_classes = dict(person=PersonUpdateForm)
 
     def get_extra_forms(self):
         self.extra_forms = {
@@ -859,12 +861,8 @@ class MRSRequestUpdateView(crudlfap.UpdateView):
     def form_valid(self):
         def d():
             data = {
-                'insured' if i == 'pk' else i: getattr(self.object.insured, i)
-                for i in (
-                    'nir',
-                    # 'birth_date',
-                    'pk'
-                )
+                'insured': self.object.pk,
+                'nir': self.object.nir,
             }
             date = getattr(self.object.insured, 'birth_date')
             if date:

--- a/src/mrsrequest/forms.py
+++ b/src/mrsrequest/forms.py
@@ -743,3 +743,9 @@ class MRSRequestForm(forms.ModelForm):
     class Meta:
         model = MRSRequest
         fields = ['distancevp']
+
+    def clean_distancevp(self):
+        value = self.cleaned_data.get('distancevp', None)
+        if self.instance.modevp and value:
+            return value
+        return self.instance.distancevp

--- a/src/mrsrequest/jinja2/mrsrequest/mrsrequest_detail.html
+++ b/src/mrsrequest/jinja2/mrsrequest/mrsrequest_detail.html
@@ -319,7 +319,12 @@
                             Montant total de la dépense VP
                         </td>
                         <td>
-                            {{ '%.2f'|format(object.distancevp * 0.3 + float(object.expensevp)) }} €TTC
+                            {% if object.distancevp %}
+                                {{ '%.2f'|format(object.distancevp * 0.3 + float(object.expensevp)) }} €TTC
+                            {% else %}
+                                <b>VIDE</b>
+                                Une modification a vidée le champs distance, voir l'historique des actions de la demande en haut à droite du corps de la page.
+                            {% endif %}
                         </td>
                     </tr>
                     <tr

--- a/src/mrsrequest/jinja2/mrsrequest/mrsrequest_detail.html
+++ b/src/mrsrequest/jinja2/mrsrequest/mrsrequest_detail.html
@@ -319,12 +319,12 @@
                             Montant total de la dépense VP
                         </td>
                         <td>
-                            {% if object.distancevp %}
-                                {{ '%.2f'|format(object.distancevp * 0.3 + float(object.expensevp)) }} €TTC
-                            {% else %}
+                        {%- if object.distancevp %}
+                            {{ '%.2f'|format(object.distancevp * 0.3 + float(object.expensevp)) }} €TTC
+                        {% else %}
                                 <b>VIDE</b>
                                 Une modification a vidée le champs distance, voir l'historique des actions de la demande en haut à droite du corps de la page.
-                            {% endif %}
+                        {% endif -%}
                         </td>
                     </tr>
                     <tr

--- a/src/mrsrequest/tests/test_mrsrequest_form.py
+++ b/src/mrsrequest/tests/test_mrsrequest_form.py
@@ -7,6 +7,7 @@ import pytest
 from mrsattachment.models import MRSAttachment
 from mrsrequest.forms import (
     MRSRequestCreateForm,
+    MRSRequestForm,
     TransportFormSet,
 )
 from mrsrequest.models import Bill, MRSRequest, PMT, Transport
@@ -239,3 +240,30 @@ def test_transport_formset_confirm_messages():
             ])
         ],
     )
+
+
+@pytest.mark.parametrize('initial,value,valid', [
+    (1, 0, False),
+    (1, None, False),
+    (1, '', False),
+    (0, 0, True),
+    (0, None, True),
+    (0, '', True),
+    (None, 0, True),
+    (None, None, True),
+    (None, '', True),
+])
+def test_mrsrequestform_distancevp_validation(initial, value, valid):
+    instance = MRSRequest(distancevp=initial, modevp=bool(initial))
+    form = MRSRequestForm(
+        {'distancevp': value},
+        instance=instance,
+    )
+    assert form.is_valid()
+    form.save(commit=False)
+    if valid and instance.modevp:
+        assert form.cleaned_data['distancevp'] == value
+        assert instance.distancevp == value
+    else:
+        assert form.cleaned_data['distancevp'] == initial
+        assert instance.distancevp == initial


### PR DESCRIPTION
Actuellement, le liquidateur peut vider le champs distance ce qui le met à null en DB, ce qui ne devrait pas être le cas de demandes avec le modevp.

Ce patch enforce la valeur initiale dans ce cas.