### PR TITLE
Doubler la queue de uWSGI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,7 +41,7 @@ steps:
 - name: safety
   image: yourlabs/python
   commands:
-  - safety check
+  - safety check -r requirements.txt
 
 - name: bandit
   image: yourlabs/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ CMD /usr/bin/dumb-init bash -euxc "djcli dbcheck && mrs migrate --noinput \
   --chmod=666 \
   --log-5xx \
   --vacuum \
+  --listen=${LISTEN-100} \
   --enable-threads \
   --post-buffering=8192 \
   --ignore-sigpipe \

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -19,6 +19,13 @@
   - include: backup.yml
     when: home is defined and lookup('env', 'RESTIC_PASSWORD')
 
+  - name: Augmentation du nombre de connections simultannées à 256
+    when: lookup('env', 'MAXCONN')
+    sysctl:
+      name: net.core.somaxconn
+      value: '{{ lookup("env", "MAXCONN") }}'
+      state: present
+
   - name: Déploiement du pod docker-compose
     include_role: name=yourlabs.compose
     vars:


### PR DESCRIPTION
Avant: queue prévue pour 100 connections simultannées
Avec ce patch: c'est doublé

Cela fait suite aux 3 minutes de downtime, le serveur etait tout bien
mais dans les logs:

django_1    | Fri Jan 15 14:16:27 2021 - *** uWSGI listen queue of socket "0.0.0.0:8000" (fd: 4) full !!! (101/100) ***
django_1    | Fri Jan 15 14:16:28 2021 - *** uWSGI listen queue of socket "0.0.0.0:8000" (fd: 4) full !!! (101/100) ***
django_1    | Fri Jan 15 14:16:29 2021 - *** uWSGI listen queue of socket "0.0.0.0:8000" (fd: 4) full !!! (101/100) ***

Il n'acceptait pas de 101eme connection.

Sur les forums, ils ont l'air de passer directement a 1024, mais cela
peut avoir des effets de bords notamment flooder le serveur, on va donc
augementer regulierement et tranquillement pour trouver le bon
parametre.